### PR TITLE
ci: 🎡 determine relevant podspec version from changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,22 @@ jobs:
         password: ${{ secrets.RSBC_USER_BASICAUTH_PWD }}
     - name: Install required tools
       run: brew install xcodegen
-    - name: Determine latest podspec versions (base is SAPCommon)
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v20.2
+      if: github.event_name != 'workflow_dispatch'
+    - name: Determine relevant podspec versions (based on changed files)
       id: frameworkVersion
       if: github.event_name != 'workflow_dispatch'
       run: |
-        cd SAPCommon
-        lastVersion=`ls -1|sort -r|head -n 1`
-        echo "$lastVersion"
-        echo "::set-output name=latest::$lastVersion"       
+        relevantVersion=7.0.5 # safeguard in case no podspec file(s) were changed
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          lastVersion=`echo ${file} | cut -d / -f 2`
+          [[ $lastVersion == [0-9]* ]] && relevantVersion=$lastVersion
+          echo "File checked: ${file}."
+        done
+        echo ${relevantVersion}
+        echo "::set-output name=latest::$relevantVersion"
     - name: Determine iOSVersion
       id: iOSVersion
       if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       id: frameworkVersion
       if: github.event_name != 'workflow_dispatch'
       run: |
-        relevantVersion=7.0.5 # safeguard in case no podspec file(s) were changed
+        relevantVersion=7.0.6 # safeguard in case no podspec file(s) were changed
         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
           lastVersion=`echo ${file} | cut -d / -f 2`
           [[ $lastVersion == [0-9]* ]] && relevantVersion=$lastVersion


### PR DESCRIPTION
Previous way to determine the relevant SDK version was incorrect. When
introducing 6.x podfiles then the determined version was 7.x. With this
commit the version will be determined by parsing the path(s) of the
changed file(s) of the commit that triggered the GitHub workflow run. In
case no podspec file was chagned/added then a fallback version (7.05) is
used.
