### PR TITLE
chore: 🤖 use compliant domain repositories.cloud.sap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Create .netrc file with credentials to download binaries from SAP RSBC
       uses: little-core-labs/netrc-creds@master
       with:
-        machine: rbsc.repositories.sap.ondemand.com
+        machine: rbsc.repositories.cloud.sap
         login: sap-sdkiospecs
         password: ${{ secrets.RSBC_USER_BASICAUTH_PWD }}
     - name: Install required tools

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ replace_in_specs: # e.g. make replace_in_specs OLD=13.0 NEW=14.0 IN_VERSION=6.1.
 	sed -i '' 's/$(OLD)/$(NEW)/' SAPOData/$(IN_VERSION)/SAPOData.podspec
 	sed -i '' 's/$(OLD)/$(NEW)/' SAPOfflineOData/$(IN_VERSION)/SAPOfflineOData.podspec
 download_zips: # e.g. make download_zips VERSION=6.1.0
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/$(VERSION)/SAPCommon-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/$(VERSION)/SAPFoundation-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/$(VERSION)/SAPFiori-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/$(VERSION)/SAPFioriFlows-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/$(VERSION)/SAPML-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/$(VERSION)/SAPOData-$(VERSION)-Release-xcframework.zip -netrc
-	curl -LO https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/$(VERSION)/SAPOfflineOData-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/$(VERSION)/SAPCommon-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/$(VERSION)/SAPFoundation-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/$(VERSION)/SAPFiori-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/$(VERSION)/SAPFioriFlows-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/$(VERSION)/SAPML-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/$(VERSION)/SAPOData-$(VERSION)-Release-xcframework.zip -netrc
+	curl -LO https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307dev/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/$(VERSION)/SAPOfflineOData-$(VERSION)-Release-xcframework.zip -netrc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-***IMPORTANT:  Due to a repository migration 7/2020, your netrc `machine` should be updated to `rbsc.repositories.sap.ondemand.com`.  You will likely experience authentication failure without making this change.*** 
+***IMPORTANT:  Due to a repository migration 7/2022, your netrc `machine` should be updated to `rbsc.repositories.cloud.sap`.  You will likely experience authentication failure without making this change.*** 
 
 # The SAP iOS SDK Specs Repo
 
@@ -10,7 +10,7 @@ This repository contains the CocoaPods specifications for frameworks in the SAP 
 
 1. Ruby
 2. Cocoapods dependency manager
-3. Technical user & password, for [repositories.sap.ondemand.com](https://rbsc.repositories.sap.ondemand.com/nexus3/)
+3. Technical user & password, for [repositories.cloud.sap](https://rbsc.repositories.cloud.sap/nexus3/)
 4. Apple Xcode IDE
 5. For SDK version >=5 on Mac Catalyst, script `codesign.py` from SAP BTP SDK for iOS Assistant
 
@@ -62,12 +62,12 @@ Open, or create a new file at `~/.netrc`.
 Add an entry which includes the username password credential pair, as follows:
 
 ```
-machine rbsc.repositories.sap.ondemand.com 
+machine rbsc.repositories.cloud.sap 
     login sap-xxxxxx 
     password xxxxxxxxxxxxxxxxxx
 ```
 
-> The `machine` name was updated 7/2020 to `rbsc.repositories.sap.ondemand.com`.  Existing netrc entries should be updated accordingly.  The existing technical user credentials *should* remain valid.  If not, please re-generate and update in the netrc file.
+> The `machine` name was updated 7/2022 to `rbsc.repositories.cloud.sap`.  Existing netrc entries should be updated accordingly.  The existing technical user credentials *should* remain valid.  If not, please re-generate and update in the netrc file.
 
 The **netrc** credential technique is a stand **cURL** API.  For complete documentation, see [gnu.org](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html).
 

--- a/SAPCommon/3.1.2/SAPCommon.podspec
+++ b/SAPCommon/3.1.2/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPCommon'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.1.200/SAPCommon-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.1.200/SAPCommon-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPCommon.framework'
   spec.framework            = 'SAPCommon'
   spec.license              = { :type => 'SAP Developer License', :text => <<-LICENSE

--- a/SAPCommon/3.1.3/SAPCommon.podspec
+++ b/SAPCommon/3.1.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPCommon'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.1.300/SAPCommon-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.1.300/SAPCommon-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPCommon.framework'
   spec.framework            = 'SAPCommon'
   spec.license              = { :type => 'SAP Developer License', :text => <<-LICENSE

--- a/SAPCommon/3.2.3/SAPCommon.podspec
+++ b/SAPCommon/3.2.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.2.300/SAPCommon-3.2.300-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.2.300/SAPCommon-3.2.300-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/3.2.6/SAPCommon.podspec
+++ b/SAPCommon/3.2.6/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.2.600/SAPCommon-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/3.2.600/SAPCommon-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.10/SAPCommon.podspec
+++ b/SAPCommon/4.0.10/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.10/SAPCommon-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.10/SAPCommon-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.11/SAPCommon.podspec
+++ b/SAPCommon/4.0.11/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.11/SAPCommon-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.11/SAPCommon-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.16/SAPCommon.podspec
+++ b/SAPCommon/4.0.16/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.15/SAPCommon-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.15/SAPCommon-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.18/SAPCommon.podspec
+++ b/SAPCommon/4.0.18/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.18/SAPCommon-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.18/SAPCommon-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.19/SAPCommon.podspec
+++ b/SAPCommon/4.0.19/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     

--- a/SAPCommon/4.0.21/SAPCommon.podspec
+++ b/SAPCommon/4.0.21/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.21/SAPCommon-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.21/SAPCommon-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.4/SAPCommon.podspec
+++ b/SAPCommon/4.0.4/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.4/SAPCommon-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.4/SAPCommon-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/4.0.7/SAPCommon.podspec
+++ b/SAPCommon/4.0.7/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.7/SAPCommon-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/4.0.7/SAPCommon-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPCommon.framework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.0.3/SAPCommon.podspec
+++ b/SAPCommon/5.0.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.3/SAPCommon-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.3/SAPCommon-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.0.5/SAPCommon.podspec
+++ b/SAPCommon/5.0.5/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.5/SAPCommon-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.5/SAPCommon-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.0.6/SAPCommon.podspec
+++ b/SAPCommon/5.0.6/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.6/SAPCommon-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.0.6/SAPCommon-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.1.0/SAPCommon.podspec
+++ b/SAPCommon/5.1.0/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     

--- a/SAPCommon/5.1.1/SAPCommon.podspec
+++ b/SAPCommon/5.1.1/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.1/SAPCommon-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.1/SAPCommon-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.1.13/SAPCommon.podspec
+++ b/SAPCommon/5.1.13/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.13/SAPCommon-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.13/SAPCommon-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.1.2/SAPCommon.podspec
+++ b/SAPCommon/5.1.2/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.2/SAPCommon-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.2/SAPCommon-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.1.3/SAPCommon.podspec
+++ b/SAPCommon/5.1.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.3/SAPCommon-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.3/SAPCommon-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     

--- a/SAPCommon/5.1.6/SAPCommon.podspec
+++ b/SAPCommon/5.1.6/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.6/SAPCommon-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.6/SAPCommon-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/5.1.8/SAPCommon.podspec
+++ b/SAPCommon/5.1.8/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.8/SAPCommon-5.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/5.1.8/SAPCommon-5.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     # spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/6.0.2/SAPCommon.podspec
+++ b/SAPCommon/6.0.2/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.0.2/SAPCommon-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.0.2/SAPCommon-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
     

--- a/SAPCommon/6.0.3/SAPCommon.podspec
+++ b/SAPCommon/6.0.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.0.3/SAPCommon-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.0.3/SAPCommon-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.0/SAPCommon.podspec
+++ b/SAPCommon/6.1.0/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.0/SAPCommon-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.0/SAPCommon-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.1/SAPCommon.podspec
+++ b/SAPCommon/6.1.1/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.1/SAPCommon-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.1/SAPCommon-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.10/SAPCommon.podspec
+++ b/SAPCommon/6.1.10/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.10/SAPCommon-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.10/SAPCommon-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.11/SAPCommon.podspec
+++ b/SAPCommon/6.1.11/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.11/SAPCommon-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.11/SAPCommon-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.12/SAPCommon.podspec
+++ b/SAPCommon/6.1.12/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.12/SAPCommon-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.12/SAPCommon-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.13/SAPCommon.podspec
+++ b/SAPCommon/6.1.13/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.13/SAPCommon-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.13/SAPCommon-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.14/SAPCommon.podspec
+++ b/SAPCommon/6.1.14/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.14/SAPCommon-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.14/SAPCommon-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.15/SAPCommon.podspec
+++ b/SAPCommon/6.1.15/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.15/SAPCommon-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.15/SAPCommon-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.16/SAPCommon.podspec
+++ b/SAPCommon/6.1.16/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.16/SAPCommon-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.16/SAPCommon-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.2/SAPCommon.podspec
+++ b/SAPCommon/6.1.2/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.2/SAPCommon-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.2/SAPCommon-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.3/SAPCommon.podspec
+++ b/SAPCommon/6.1.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.3/SAPCommon-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.3/SAPCommon-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.4/SAPCommon.podspec
+++ b/SAPCommon/6.1.4/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.4/SAPCommon-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.4/SAPCommon-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.5/SAPCommon.podspec
+++ b/SAPCommon/6.1.5/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.5/SAPCommon-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.5/SAPCommon-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.7/SAPCommon.podspec
+++ b/SAPCommon/6.1.7/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.7/SAPCommon-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.7/SAPCommon-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/6.1.8/SAPCommon.podspec
+++ b/SAPCommon/6.1.8/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.8/SAPCommon-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/6.1.8/SAPCommon-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.0/SAPCommon.podspec
+++ b/SAPCommon/7.0.0/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.0/SAPCommon-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.0/SAPCommon-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.1/SAPCommon.podspec
+++ b/SAPCommon/7.0.1/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.1/SAPCommon-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.1/SAPCommon-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.2/SAPCommon.podspec
+++ b/SAPCommon/7.0.2/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.2/SAPCommon-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.2/SAPCommon-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.3/SAPCommon.podspec
+++ b/SAPCommon/7.0.3/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.3/SAPCommon-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.3/SAPCommon-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.4/SAPCommon.podspec
+++ b/SAPCommon/7.0.4/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.4/SAPCommon-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.4/SAPCommon-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.5/SAPCommon.podspec
+++ b/SAPCommon/7.0.5/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.5/SAPCommon-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.5/SAPCommon-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.6/SAPCommon.podspec
+++ b/SAPCommon/7.0.6/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.6/SAPCommon-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.6/SAPCommon-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/7.0.7/SAPCommon.podspec
+++ b/SAPCommon/7.0.7/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.7/SAPCommon-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/7.0.7/SAPCommon-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPCommon/8.0.0/SAPCommon.podspec
+++ b/SAPCommon/8.0.0/SAPCommon.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPCommon Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/8.0.0/SAPCommon-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPCommon/8.0.0/SAPCommon-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPCommon.xcframework'
     spec.framework            = 'SAPCommon'
 

--- a/SAPFiori/3.1.2/SAPFiori.podspec
+++ b/SAPFiori/3.1.2/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFiori'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.1.200/SAPFiori-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.1.200/SAPFiori-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFiori.framework'
   spec.framework            = 'SAPFiori'
   spec.dependency           'SAPCommon', '3.1.2'

--- a/SAPFiori/3.1.3/SAPFiori.podspec
+++ b/SAPFiori/3.1.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFiori'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.1.300/SAPFiori-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.1.300/SAPFiori-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFiori.framework'
   spec.framework            = 'SAPFiori'
   spec.dependency           'SAPCommon', '3.1.3'

--- a/SAPFiori/3.2.3/SAPFiori.podspec
+++ b/SAPFiori/3.2.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.2.300/SAPFiori-3.2.300-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.2.300/SAPFiori-3.2.300-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '3.2.3'

--- a/SAPFiori/3.2.6/SAPFiori.podspec
+++ b/SAPFiori/3.2.6/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.2.600/SAPFiori-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/3.2.600/SAPFiori-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '3.2.6'

--- a/SAPFiori/4.0.10/SAPFiori.podspec
+++ b/SAPFiori/4.0.10/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.10/SAPFiori-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.10/SAPFiori-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.10'

--- a/SAPFiori/4.0.11/SAPFiori.podspec
+++ b/SAPFiori/4.0.11/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.11/SAPFiori-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.11/SAPFiori-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.11'

--- a/SAPFiori/4.0.16/SAPFiori.podspec
+++ b/SAPFiori/4.0.16/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.15/SAPFiori-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.15/SAPFiori-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.16'

--- a/SAPFiori/4.0.18/SAPFiori.podspec
+++ b/SAPFiori/4.0.18/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.18/SAPFiori-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.18/SAPFiori-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.18'

--- a/SAPFiori/4.0.19/SAPFiori.podspec
+++ b/SAPFiori/4.0.19/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFiori/4.0.21/SAPFiori.podspec
+++ b/SAPFiori/4.0.21/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.21/SAPFiori-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.21/SAPFiori-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.21'

--- a/SAPFiori/4.0.4/SAPFiori.podspec
+++ b/SAPFiori/4.0.4/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.4/SAPFiori-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.4/SAPFiori-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.4'

--- a/SAPFiori/4.0.7/SAPFiori.podspec
+++ b/SAPFiori/4.0.7/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.7/SAPFiori-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.7/SAPFiori-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.7'

--- a/SAPFiori/4.0.8/SAPFiori.podspec
+++ b/SAPFiori/4.0.8/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.8/SAPFiori-4.0.8-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/4.0.8/SAPFiori-4.0.8-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFiori.framework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '4.0.7'

--- a/SAPFiori/5.0.3/SAPFiori.podspec
+++ b/SAPFiori/5.0.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.3/SAPFiori-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.3/SAPFiori-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.0.3'

--- a/SAPFiori/5.0.4/SAPFiori.podspec
+++ b/SAPFiori/5.0.4/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.4/SAPFiori-5.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.4/SAPFiori-5.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.0.3'

--- a/SAPFiori/5.0.5/SAPFiori.podspec
+++ b/SAPFiori/5.0.5/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.5/SAPFiori-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.5/SAPFiori-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.0.5'

--- a/SAPFiori/5.0.6/SAPFiori.podspec
+++ b/SAPFiori/5.0.6/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.6/SAPFiori-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.0.6/SAPFiori-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.0.6'

--- a/SAPFiori/5.1.0/SAPFiori.podspec
+++ b/SAPFiori/5.1.0/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFiori/5.1.1/SAPFiori.podspec
+++ b/SAPFiori/5.1.1/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.1/SAPFiori-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.1/SAPFiori-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.1.1'

--- a/SAPFiori/5.1.13/SAPFiori.podspec
+++ b/SAPFiori/5.1.13/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.13/SAPFiori-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.13/SAPFiori-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.1.13'

--- a/SAPFiori/5.1.2/SAPFiori.podspec
+++ b/SAPFiori/5.1.2/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.2/SAPFiori-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.2/SAPFiori-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.1.2'

--- a/SAPFiori/5.1.3/SAPFiori.podspec
+++ b/SAPFiori/5.1.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.3/SAPFiori-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.3/SAPFiori-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFiori/5.1.6/SAPFiori.podspec
+++ b/SAPFiori/5.1.6/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.6/SAPFiori-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/5.1.6/SAPFiori-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '5.1.6'

--- a/SAPFiori/6.0.2/SAPFiori.podspec
+++ b/SAPFiori/6.0.2/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.0.2/SAPFiori-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.0.2/SAPFiori-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.0.2'

--- a/SAPFiori/6.0.3/SAPFiori.podspec
+++ b/SAPFiori/6.0.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.0.3/SAPFiori-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.0.3/SAPFiori-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.0.3'

--- a/SAPFiori/6.1.0/SAPFiori.podspec
+++ b/SAPFiori/6.1.0/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.0/SAPFiori-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.0/SAPFiori-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.0'

--- a/SAPFiori/6.1.1/SAPFiori.podspec
+++ b/SAPFiori/6.1.1/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.1/SAPFiori-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.1/SAPFiori-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.1'

--- a/SAPFiori/6.1.10/SAPFiori.podspec
+++ b/SAPFiori/6.1.10/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.10/SAPFiori-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.10/SAPFiori-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.10'

--- a/SAPFiori/6.1.11/SAPFiori.podspec
+++ b/SAPFiori/6.1.11/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.11/SAPFiori-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.11/SAPFiori-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.11'

--- a/SAPFiori/6.1.12/SAPFiori.podspec
+++ b/SAPFiori/6.1.12/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.12/SAPFiori-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.12/SAPFiori-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.12'

--- a/SAPFiori/6.1.13/SAPFiori.podspec
+++ b/SAPFiori/6.1.13/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.13/SAPFiori-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.13/SAPFiori-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.13'

--- a/SAPFiori/6.1.14/SAPFiori.podspec
+++ b/SAPFiori/6.1.14/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.14/SAPFiori-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.14/SAPFiori-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.14'

--- a/SAPFiori/6.1.15/SAPFiori.podspec
+++ b/SAPFiori/6.1.15/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.15/SAPFiori-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.15/SAPFiori-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.15'

--- a/SAPFiori/6.1.16/SAPFiori.podspec
+++ b/SAPFiori/6.1.16/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.16/SAPFiori-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.16/SAPFiori-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.16'

--- a/SAPFiori/6.1.2/SAPFiori.podspec
+++ b/SAPFiori/6.1.2/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.2/SAPFiori-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.2/SAPFiori-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.2'

--- a/SAPFiori/6.1.3/SAPFiori.podspec
+++ b/SAPFiori/6.1.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.3/SAPFiori-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.3/SAPFiori-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.3'

--- a/SAPFiori/6.1.4/SAPFiori.podspec
+++ b/SAPFiori/6.1.4/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.4/SAPFiori-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.4/SAPFiori-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.4'

--- a/SAPFiori/6.1.5/SAPFiori.podspec
+++ b/SAPFiori/6.1.5/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.5/SAPFiori-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.5/SAPFiori-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.5'

--- a/SAPFiori/6.1.7/SAPFiori.podspec
+++ b/SAPFiori/6.1.7/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.7/SAPFiori-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.7/SAPFiori-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.7'

--- a/SAPFiori/6.1.8/SAPFiori.podspec
+++ b/SAPFiori/6.1.8/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.8/SAPFiori-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/6.1.8/SAPFiori-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '6.1.8'

--- a/SAPFiori/7.0.0/SAPFiori.podspec
+++ b/SAPFiori/7.0.0/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.0/SAPFiori-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.0/SAPFiori-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.0'

--- a/SAPFiori/7.0.1/SAPFiori.podspec
+++ b/SAPFiori/7.0.1/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.1/SAPFiori-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.1/SAPFiori-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.1'

--- a/SAPFiori/7.0.2/SAPFiori.podspec
+++ b/SAPFiori/7.0.2/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.2/SAPFiori-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.2/SAPFiori-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.2'

--- a/SAPFiori/7.0.3/SAPFiori.podspec
+++ b/SAPFiori/7.0.3/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.3/SAPFiori-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.3/SAPFiori-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.3'

--- a/SAPFiori/7.0.4/SAPFiori.podspec
+++ b/SAPFiori/7.0.4/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.4/SAPFiori-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.4/SAPFiori-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.4'

--- a/SAPFiori/7.0.5/SAPFiori.podspec
+++ b/SAPFiori/7.0.5/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.5/SAPFiori-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.5/SAPFiori-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.5'

--- a/SAPFiori/7.0.6/SAPFiori.podspec
+++ b/SAPFiori/7.0.6/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.6/SAPFiori-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.6/SAPFiori-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.6'

--- a/SAPFiori/7.0.7/SAPFiori.podspec
+++ b/SAPFiori/7.0.7/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.7/SAPFiori-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/7.0.7/SAPFiori-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '7.0.7'

--- a/SAPFiori/8.0.0/SAPFiori.podspec
+++ b/SAPFiori/8.0.0/SAPFiori.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFiori Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/8.0.0/SAPFiori-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPFiori/8.0.0/SAPFiori-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFiori.xcframework'
     spec.framework            = 'SAPFiori'
     spec.dependency  'SAPCommon', '8.0.0'

--- a/SAPFioriFlows/3.1.2/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/3.1.2/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFioriFlows'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.1.200/SAPFioriFlows-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.1.200/SAPFioriFlows-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFioriFlows.framework'
   spec.framework            = 'SAPFioriFlows'
   spec.dependency           'SAPCommon', '3.1.2'

--- a/SAPFioriFlows/3.1.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/3.1.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFioriFlows'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.1.300/SAPFioriFlows-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.1.300/SAPFioriFlows-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFioriFlows.framework'
   spec.framework            = 'SAPFioriFlows'
   spec.dependency           'SAPCommon', '3.1.3'

--- a/SAPFioriFlows/3.2.6/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/3.2.6/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.2.600/SAPFioriFlows-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/3.2.600/SAPFioriFlows-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '3.2.6'

--- a/SAPFioriFlows/4.0.10/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.10/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.10/SAPFioriFlows-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.10/SAPFioriFlows-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '4.0.10'

--- a/SAPFioriFlows/4.0.11/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.11/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.11/SAPFioriFlows-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.11/SAPFioriFlows-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '4.0.11'

--- a/SAPFioriFlows/4.0.16/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.16/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.15/SAPFioriFlows-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.15/SAPFioriFlows-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '4.0.16'

--- a/SAPFioriFlows/4.0.18/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.18/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.18/SAPFioriFlows-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.18/SAPFioriFlows-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '4.0.18'

--- a/SAPFioriFlows/4.0.19/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.19/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPFoundation', "#{spec.version}"

--- a/SAPFioriFlows/4.0.21/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.21/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.21/SAPFioriFlows-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.21/SAPFioriFlows-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '4.0.21'

--- a/SAPFioriFlows/4.0.4/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.4/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.4/SAPFioriFlows-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.4/SAPFioriFlows-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '4.0.4'

--- a/SAPFioriFlows/4.0.7/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.7/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.7/SAPFioriFlows-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.7/SAPFioriFlows-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '4.0.7'

--- a/SAPFioriFlows/4.0.8/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/4.0.8/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.8/SAPFioriFlows-4.0.8-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/4.0.8/SAPFioriFlows-4.0.8-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.framework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '4.0.7'

--- a/SAPFioriFlows/5.0.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.0.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.3/SAPFioriFlows-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.3/SAPFioriFlows-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '5.0.3'

--- a/SAPFioriFlows/5.0.4/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.0.4/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.4/SAPFioriFlows-5.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.4/SAPFioriFlows-5.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '5.0.4'

--- a/SAPFioriFlows/5.0.5/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.0.5/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.5/SAPFioriFlows-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.5/SAPFioriFlows-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '5.0.5'

--- a/SAPFioriFlows/5.0.6/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.0.6/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.6/SAPFioriFlows-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.0.6/SAPFioriFlows-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '5.0.6'

--- a/SAPFioriFlows/5.1.0/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.0/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPFiori', "#{spec.version}"

--- a/SAPFioriFlows/5.1.1/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.1/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.1/SAPFioriFlows-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.1/SAPFioriFlows-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '5.1.1'

--- a/SAPFioriFlows/5.1.13/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.13/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.13/SAPFioriFlows-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.13/SAPFioriFlows-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFiori', '5.1.13'

--- a/SAPFioriFlows/5.1.2/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.2/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.2/SAPFioriFlows-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.2/SAPFioriFlows-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '5.1.2'

--- a/SAPFioriFlows/5.1.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.3/SAPFioriFlows-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.3/SAPFioriFlows-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPFiori', "#{spec.version}"

--- a/SAPFioriFlows/5.1.6/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/5.1.6/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.6/SAPFioriFlows-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/5.1.6/SAPFioriFlows-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPFoundation', '5.1.6'

--- a/SAPFioriFlows/6.0.2/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.0.2/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.0.2/SAPFioriFlows-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.0.2/SAPFioriFlows-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.0.2'

--- a/SAPFioriFlows/6.0.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.0.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.0.3/SAPFioriFlows-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.0.3/SAPFioriFlows-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.0.3'

--- a/SAPFioriFlows/6.1.0/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.0/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.0/SAPFioriFlows-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.0/SAPFioriFlows-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.0'

--- a/SAPFioriFlows/6.1.1/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.1/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.1/SAPFioriFlows-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.1/SAPFioriFlows-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.1'

--- a/SAPFioriFlows/6.1.10/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.10/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.10/SAPFioriFlows-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.10/SAPFioriFlows-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.10'

--- a/SAPFioriFlows/6.1.11/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.11/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.11/SAPFioriFlows-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.11/SAPFioriFlows-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.11'

--- a/SAPFioriFlows/6.1.12/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.12/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.12/SAPFioriFlows-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.12/SAPFioriFlows-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.12'

--- a/SAPFioriFlows/6.1.13/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.13/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.13/SAPFioriFlows-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.13/SAPFioriFlows-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.13'

--- a/SAPFioriFlows/6.1.14/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.14/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.14/SAPFioriFlows-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.14/SAPFioriFlows-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.14'

--- a/SAPFioriFlows/6.1.15/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.15/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.15/SAPFioriFlows-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.15/SAPFioriFlows-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.15'

--- a/SAPFioriFlows/6.1.16/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.16/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.16/SAPFioriFlows-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.16/SAPFioriFlows-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.16'

--- a/SAPFioriFlows/6.1.2/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.2/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.2/SAPFioriFlows-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.2/SAPFioriFlows-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.2'

--- a/SAPFioriFlows/6.1.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.3/SAPFioriFlows-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.3/SAPFioriFlows-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.3'

--- a/SAPFioriFlows/6.1.4/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.4/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.4/SAPFioriFlows-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.4/SAPFioriFlows-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.4'

--- a/SAPFioriFlows/6.1.5/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.5/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.5/SAPFioriFlows-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.5/SAPFioriFlows-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.5'

--- a/SAPFioriFlows/6.1.7/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.7/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.7/SAPFioriFlows-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.7/SAPFioriFlows-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.7'

--- a/SAPFioriFlows/6.1.8/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/6.1.8/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.8/SAPFioriFlows-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/6.1.8/SAPFioriFlows-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '6.1.8'

--- a/SAPFioriFlows/7.0.0/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.0/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.0/SAPFioriFlows-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.0/SAPFioriFlows-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.0'

--- a/SAPFioriFlows/7.0.1/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.1/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.1/SAPFioriFlows-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.1/SAPFioriFlows-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.1'

--- a/SAPFioriFlows/7.0.2/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.2/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.2/SAPFioriFlows-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.2/SAPFioriFlows-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.2'

--- a/SAPFioriFlows/7.0.3/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.3/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.3/SAPFioriFlows-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.3/SAPFioriFlows-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.3'

--- a/SAPFioriFlows/7.0.4/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.4/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.4/SAPFioriFlows-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.4/SAPFioriFlows-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.4'

--- a/SAPFioriFlows/7.0.5/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.5/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.5/SAPFioriFlows-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.5/SAPFioriFlows-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.5'

--- a/SAPFioriFlows/7.0.6/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.6/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.6/SAPFioriFlows-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.6/SAPFioriFlows-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.6'

--- a/SAPFioriFlows/7.0.7/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/7.0.7/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.7/SAPFioriFlows-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/7.0.7/SAPFioriFlows-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '7.0.7'

--- a/SAPFioriFlows/8.0.0/SAPFioriFlows.podspec
+++ b/SAPFioriFlows/8.0.0/SAPFioriFlows.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFioriFlows Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/8.0.0/SAPFioriFlows-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/flows/SAPFioriFlows/8.0.0/SAPFioriFlows-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFioriFlows.xcframework'
     spec.framework            = 'SAPFioriFlows'
     spec.dependency  'SAPCommon', '8.0.0'

--- a/SAPFoundation/3.1.2/SAPFoundation.podspec
+++ b/SAPFoundation/3.1.2/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFoundation'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.1.200/SAPFoundation-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.1.200/SAPFoundation-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFoundation.framework'
   spec.framework            = 'SAPFoundation'
   spec.dependency           'SAPCommon', '3.1.2'

--- a/SAPFoundation/3.1.3/SAPFoundation.podspec
+++ b/SAPFoundation/3.1.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPFoundation'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.1.300/SAPFoundation-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.1.300/SAPFoundation-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPFoundation.framework'
   spec.framework            = 'SAPFoundation'
   spec.dependency           'SAPCommon', '3.1.3'

--- a/SAPFoundation/3.2.3/SAPFoundation.podspec
+++ b/SAPFoundation/3.2.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.2.300/SAPFoundation-3.2.300-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.2.300/SAPFoundation-3.2.300-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '3.2.3'

--- a/SAPFoundation/3.2.6/SAPFoundation.podspec
+++ b/SAPFoundation/3.2.6/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.2.600/SAPFoundation-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/3.2.600/SAPFoundation-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '3.2.6'

--- a/SAPFoundation/4.0.10/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.10/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.10/SAPFoundation-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.10/SAPFoundation-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.10'

--- a/SAPFoundation/4.0.11/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.11/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.11/SAPFoundation-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.11/SAPFoundation-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.11'

--- a/SAPFoundation/4.0.16/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.16/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.15/SAPFoundation-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.15/SAPFoundation-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.16'

--- a/SAPFoundation/4.0.18/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.18/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.18/SAPFoundation-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.18/SAPFoundation-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.18'

--- a/SAPFoundation/4.0.19/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.19/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFoundation/4.0.21/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.21/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.21/SAPFoundation-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.21/SAPFoundation-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.21'

--- a/SAPFoundation/4.0.4/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.4/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.4/SAPFoundation-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.4/SAPFoundation-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.4'

--- a/SAPFoundation/4.0.7/SAPFoundation.podspec
+++ b/SAPFoundation/4.0.7/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.7/SAPFoundation-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/4.0.7/SAPFoundation-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.framework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '4.0.7'

--- a/SAPFoundation/5.0.3/SAPFoundation.podspec
+++ b/SAPFoundation/5.0.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.3/SAPFoundation-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.3/SAPFoundation-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.0.3'

--- a/SAPFoundation/5.0.5/SAPFoundation.podspec
+++ b/SAPFoundation/5.0.5/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.5/SAPFoundation-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.5/SAPFoundation-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.0.5'

--- a/SAPFoundation/5.0.6/SAPFoundation.podspec
+++ b/SAPFoundation/5.0.6/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.6/SAPFoundation-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.0.6/SAPFoundation-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.0.6'

--- a/SAPFoundation/5.1.0/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.0/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/5.1.0/#{spec.name}-5.1.0-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/5.1.0/#{spec.name}-5.1.0-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFoundation/5.1.1/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.1/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.1/SAPFoundation-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.1/SAPFoundation-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.1.1'

--- a/SAPFoundation/5.1.13/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.13/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.13/SAPFoundation-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.13/SAPFoundation-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.1.13'

--- a/SAPFoundation/5.1.2/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.2/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.2/SAPFoundation-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.2/SAPFoundation-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.1.2'

--- a/SAPFoundation/5.1.3/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.3/SAPFoundation-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.3/SAPFoundation-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPFoundation/5.1.6/SAPFoundation.podspec
+++ b/SAPFoundation/5.1.6/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.6/SAPFoundation-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/5.1.6/SAPFoundation-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '5.1.6'

--- a/SAPFoundation/6.0.2/SAPFoundation.podspec
+++ b/SAPFoundation/6.0.2/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.0.2/SAPFoundation-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.0.2/SAPFoundation-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.0.2'

--- a/SAPFoundation/6.0.3/SAPFoundation.podspec
+++ b/SAPFoundation/6.0.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.0.3/SAPFoundation-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.0.3/SAPFoundation-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.0.3'

--- a/SAPFoundation/6.1.0/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.0/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.0/SAPFoundation-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.0/SAPFoundation-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.0'

--- a/SAPFoundation/6.1.1/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.1/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.1/SAPFoundation-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.1/SAPFoundation-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.1'

--- a/SAPFoundation/6.1.10/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.10/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.10/SAPFoundation-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.10/SAPFoundation-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.10'

--- a/SAPFoundation/6.1.11/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.11/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.11/SAPFoundation-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.11/SAPFoundation-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.11'

--- a/SAPFoundation/6.1.12/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.12/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.12/SAPFoundation-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.12/SAPFoundation-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.12'

--- a/SAPFoundation/6.1.13/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.13/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.13/SAPFoundation-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.13/SAPFoundation-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.13'

--- a/SAPFoundation/6.1.14/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.14/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.14/SAPFoundation-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.14/SAPFoundation-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.14'

--- a/SAPFoundation/6.1.15/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.15/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.15/SAPFoundation-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.15/SAPFoundation-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.15'

--- a/SAPFoundation/6.1.16/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.16/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.16/SAPFoundation-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.16/SAPFoundation-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.16'

--- a/SAPFoundation/6.1.2/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.2/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.2/SAPFoundation-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.2/SAPFoundation-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.2'

--- a/SAPFoundation/6.1.3/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.3/SAPFoundation-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.3/SAPFoundation-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.3'

--- a/SAPFoundation/6.1.4/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.4/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.4/SAPFoundation-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.4/SAPFoundation-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.4'

--- a/SAPFoundation/6.1.5/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.5/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.5/SAPFoundation-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.5/SAPFoundation-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.5'

--- a/SAPFoundation/6.1.7/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.7/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.7/SAPFoundation-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.7/SAPFoundation-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.7'

--- a/SAPFoundation/6.1.8/SAPFoundation.podspec
+++ b/SAPFoundation/6.1.8/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.8/SAPFoundation-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/6.1.8/SAPFoundation-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '6.1.8'

--- a/SAPFoundation/7.0.0/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.0/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.0/SAPFoundation-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.0/SAPFoundation-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.0'

--- a/SAPFoundation/7.0.1/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.1/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.1/SAPFoundation-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.1/SAPFoundation-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.1'

--- a/SAPFoundation/7.0.2/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.2/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.2/SAPFoundation-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.2/SAPFoundation-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.2'

--- a/SAPFoundation/7.0.3/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.3/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.3/SAPFoundation-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.3/SAPFoundation-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.3'

--- a/SAPFoundation/7.0.4/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.4/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.4/SAPFoundation-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.4/SAPFoundation-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.4'

--- a/SAPFoundation/7.0.5/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.5/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.5/SAPFoundation-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.5/SAPFoundation-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.5'

--- a/SAPFoundation/7.0.6/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.6/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.6/SAPFoundation-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.6/SAPFoundation-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.6'

--- a/SAPFoundation/7.0.7/SAPFoundation.podspec
+++ b/SAPFoundation/7.0.7/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.7/SAPFoundation-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/7.0.7/SAPFoundation-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '7.0.7'

--- a/SAPFoundation/8.0.0/SAPFoundation.podspec
+++ b/SAPFoundation/8.0.0/SAPFoundation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPFoundation Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/8.0.0/SAPFoundation-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPFoundation/8.0.0/SAPFoundation-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPFoundation.xcframework'
     spec.framework            = 'SAPFoundation'
     spec.dependency  'SAPCommon', '8.0.0'

--- a/SAPML/5.1.1/SAPML.podspec
+++ b/SAPML/5.1.1/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.1/SAPML-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.1/SAPML-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '5.1.1'

--- a/SAPML/5.1.13/SAPML.podspec
+++ b/SAPML/5.1.13/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.13/SAPML-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.13/SAPML-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '5.1.13'

--- a/SAPML/5.1.3/SAPML.podspec
+++ b/SAPML/5.1.3/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.3/SAPML-5.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/5.1.3/SAPML-5.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPML/5.1.6/SAPML.podspec
+++ b/SAPML/5.1.6/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/#{spec.version}/SAPML-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/#{spec.version}/SAPML-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPML/6.0.2/SAPML.podspec
+++ b/SAPML/6.0.2/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.0.2/SAPML-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.0.2/SAPML-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.0.2'

--- a/SAPML/6.0.3/SAPML.podspec
+++ b/SAPML/6.0.3/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.0.3/SAPML-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.0.3/SAPML-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.0.3'

--- a/SAPML/6.1.0/SAPML.podspec
+++ b/SAPML/6.1.0/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.0/SAPML-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.0/SAPML-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.0'

--- a/SAPML/6.1.1/SAPML.podspec
+++ b/SAPML/6.1.1/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.1/SAPML-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.1/SAPML-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.1'

--- a/SAPML/6.1.10/SAPML.podspec
+++ b/SAPML/6.1.10/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.10/SAPML-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.10/SAPML-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.10'

--- a/SAPML/6.1.11/SAPML.podspec
+++ b/SAPML/6.1.11/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.11/SAPML-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.11/SAPML-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.11'

--- a/SAPML/6.1.12/SAPML.podspec
+++ b/SAPML/6.1.12/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.12/SAPML-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.12/SAPML-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.12'

--- a/SAPML/6.1.13/SAPML.podspec
+++ b/SAPML/6.1.13/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.13/SAPML-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.13/SAPML-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.13'

--- a/SAPML/6.1.14/SAPML.podspec
+++ b/SAPML/6.1.14/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.14/SAPML-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.14/SAPML-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.14'

--- a/SAPML/6.1.15/SAPML.podspec
+++ b/SAPML/6.1.15/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.15/SAPML-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.15/SAPML-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.15'

--- a/SAPML/6.1.16/SAPML.podspec
+++ b/SAPML/6.1.16/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.16/SAPML-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.16/SAPML-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.16'

--- a/SAPML/6.1.2/SAPML.podspec
+++ b/SAPML/6.1.2/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.2/SAPML-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.2/SAPML-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.2'

--- a/SAPML/6.1.3/SAPML.podspec
+++ b/SAPML/6.1.3/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.3/SAPML-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.3/SAPML-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.3'

--- a/SAPML/6.1.4/SAPML.podspec
+++ b/SAPML/6.1.4/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.4/SAPML-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.4/SAPML-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.4'

--- a/SAPML/6.1.5/SAPML.podspec
+++ b/SAPML/6.1.5/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.5/SAPML-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.5/SAPML-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.5'

--- a/SAPML/6.1.7/SAPML.podspec
+++ b/SAPML/6.1.7/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.7/SAPML-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.7/SAPML-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.7'

--- a/SAPML/6.1.8/SAPML.podspec
+++ b/SAPML/6.1.8/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.8/SAPML-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/6.1.8/SAPML-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '6.1.8'

--- a/SAPML/7.0.0/SAPML.podspec
+++ b/SAPML/7.0.0/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.0/SAPML-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.0/SAPML-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.0'

--- a/SAPML/7.0.1/SAPML.podspec
+++ b/SAPML/7.0.1/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.1/SAPML-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.1/SAPML-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.1'

--- a/SAPML/7.0.2/SAPML.podspec
+++ b/SAPML/7.0.2/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.2/SAPML-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.2/SAPML-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.2'

--- a/SAPML/7.0.3/SAPML.podspec
+++ b/SAPML/7.0.3/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.3/SAPML-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.3/SAPML-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.3'

--- a/SAPML/7.0.4/SAPML.podspec
+++ b/SAPML/7.0.4/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.4/SAPML-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.4/SAPML-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.4'

--- a/SAPML/7.0.5/SAPML.podspec
+++ b/SAPML/7.0.5/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.5/SAPML-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.5/SAPML-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.5'

--- a/SAPML/7.0.6/SAPML.podspec
+++ b/SAPML/7.0.6/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.6/SAPML-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.6/SAPML-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.6'

--- a/SAPML/7.0.7/SAPML.podspec
+++ b/SAPML/7.0.7/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.7/SAPML-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/7.0.7/SAPML-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '7.0.7'

--- a/SAPML/8.0.0/SAPML.podspec
+++ b/SAPML/8.0.0/SAPML.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPML Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/8.0.0/SAPML-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/uireuse/SAPML/8.0.0/SAPML-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPML.xcframework'
     spec.framework            = 'SAPML'
     spec.dependency  'SAPCommon', '8.0.0'

--- a/SAPOData/3.1.2/SAPOData.podspec
+++ b/SAPOData/3.1.2/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPOData'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.1.200/SAPOData-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.1.200/SAPOData-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPOData.framework'
   spec.framework            = 'SAPOData'
   spec.dependency           'SAPCommon', '3.1.2'

--- a/SAPOData/3.1.3/SAPOData.podspec
+++ b/SAPOData/3.1.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPOData'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.1.300/SAPOData-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.1.300/SAPOData-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPOData.framework'
   spec.framework            = 'SAPOData'
   spec.dependency           'SAPCommon', '3.1.3'

--- a/SAPOData/3.2.3/SAPOData.podspec
+++ b/SAPOData/3.2.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.2.300/SAPOData-3.2.300-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.2.300/SAPOData-3.2.300-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '3.2.3'

--- a/SAPOData/3.2.6/SAPOData.podspec
+++ b/SAPOData/3.2.6/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.2.600/SAPOData-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/3.2.600/SAPOData-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '3.2.6'

--- a/SAPOData/4.0.10/SAPOData.podspec
+++ b/SAPOData/4.0.10/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.10/SAPOData-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.10/SAPOData-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '4.0.10'

--- a/SAPOData/4.0.11/SAPOData.podspec
+++ b/SAPOData/4.0.11/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.11/SAPOData-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.11/SAPOData-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '4.0.11'

--- a/SAPOData/4.0.16/SAPOData.podspec
+++ b/SAPOData/4.0.16/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.15/SAPOData-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.15/SAPOData-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '4.0.16'

--- a/SAPOData/4.0.18/SAPOData.podspec
+++ b/SAPOData/4.0.18/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.18/SAPOData-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.18/SAPOData-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '4.0.18'

--- a/SAPOData/4.0.19/SAPOData.podspec
+++ b/SAPOData/4.0.19/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPOData/4.0.21/SAPOData.podspec
+++ b/SAPOData/4.0.21/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.21/SAPOData-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.21/SAPOData-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '4.0.21'

--- a/SAPOData/4.0.4/SAPOData.podspec
+++ b/SAPOData/4.0.4/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.4/SAPOData-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.4/SAPOData-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '4.0.4'

--- a/SAPOData/4.0.7/SAPOData.podspec
+++ b/SAPOData/4.0.7/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.7/SAPOData-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/4.0.7/SAPOData-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOData.framework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '4.0.7'

--- a/SAPOData/5.0.3/SAPOData.podspec
+++ b/SAPOData/5.0.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.3/SAPOData-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.3/SAPOData-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '5.0.3'

--- a/SAPOData/5.0.5/SAPOData.podspec
+++ b/SAPOData/5.0.5/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.5/SAPOData-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.5/SAPOData-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '5.0.5'

--- a/SAPOData/5.0.6/SAPOData.podspec
+++ b/SAPOData/5.0.6/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.6/SAPOData-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.0.6/SAPOData-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPCommon', '5.0.6'

--- a/SAPOData/5.1.0/SAPOData.podspec
+++ b/SAPOData/5.1.0/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPOData/5.1.1/SAPOData.podspec
+++ b/SAPOData/5.1.1/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.1/SAPOData-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.1/SAPOData-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '5.1.1'

--- a/SAPOData/5.1.13/SAPOData.podspec
+++ b/SAPOData/5.1.13/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.13/SAPOData-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.13/SAPOData-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '5.1.13'

--- a/SAPOData/5.1.2/SAPOData.podspec
+++ b/SAPOData/5.1.2/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.2/SAPOData-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.2/SAPOData-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '5.1.2'

--- a/SAPOData/5.1.3/SAPOData.podspec
+++ b/SAPOData/5.1.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.3/SAPOData-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.3/SAPOData-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPOData/5.1.6/SAPOData.podspec
+++ b/SAPOData/5.1.6/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.6/SAPOData-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/5.1.6/SAPOData-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '5.1.6'

--- a/SAPOData/6.0.2/SAPOData.podspec
+++ b/SAPOData/6.0.2/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.0.2/SAPOData-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.0.2/SAPOData-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.0.2'

--- a/SAPOData/6.0.3/SAPOData.podspec
+++ b/SAPOData/6.0.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.0.3/SAPOData-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.0.3/SAPOData-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.0.3'

--- a/SAPOData/6.1.0/SAPOData.podspec
+++ b/SAPOData/6.1.0/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.0/SAPOData-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.0/SAPOData-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.0'

--- a/SAPOData/6.1.1/SAPOData.podspec
+++ b/SAPOData/6.1.1/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.1/SAPOData-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.1/SAPOData-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.1'

--- a/SAPOData/6.1.10/SAPOData.podspec
+++ b/SAPOData/6.1.10/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.10/SAPOData-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.10/SAPOData-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.10'

--- a/SAPOData/6.1.11/SAPOData.podspec
+++ b/SAPOData/6.1.11/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.11/SAPOData-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.11/SAPOData-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.11'

--- a/SAPOData/6.1.12/SAPOData.podspec
+++ b/SAPOData/6.1.12/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.12/SAPOData-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.12/SAPOData-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.12'

--- a/SAPOData/6.1.13/SAPOData.podspec
+++ b/SAPOData/6.1.13/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.13/SAPOData-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.13/SAPOData-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.13'

--- a/SAPOData/6.1.14/SAPOData.podspec
+++ b/SAPOData/6.1.14/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.14/SAPOData-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.14/SAPOData-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.14'

--- a/SAPOData/6.1.15/SAPOData.podspec
+++ b/SAPOData/6.1.15/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.15/SAPOData-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.15/SAPOData-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.15'

--- a/SAPOData/6.1.16/SAPOData.podspec
+++ b/SAPOData/6.1.16/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.16/SAPOData-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.16/SAPOData-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.16'

--- a/SAPOData/6.1.2/SAPOData.podspec
+++ b/SAPOData/6.1.2/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.2/SAPOData-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.2/SAPOData-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.2'

--- a/SAPOData/6.1.3/SAPOData.podspec
+++ b/SAPOData/6.1.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.3/SAPOData-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.3/SAPOData-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.3'

--- a/SAPOData/6.1.4/SAPOData.podspec
+++ b/SAPOData/6.1.4/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.4/SAPOData-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.4/SAPOData-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.4'

--- a/SAPOData/6.1.5/SAPOData.podspec
+++ b/SAPOData/6.1.5/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.5/SAPOData-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.5/SAPOData-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.5'

--- a/SAPOData/6.1.7/SAPOData.podspec
+++ b/SAPOData/6.1.7/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.7/SAPOData-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.7/SAPOData-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.7'

--- a/SAPOData/6.1.8/SAPOData.podspec
+++ b/SAPOData/6.1.8/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.8/SAPOData-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/6.1.8/SAPOData-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '6.1.8'

--- a/SAPOData/7.0.0/SAPOData.podspec
+++ b/SAPOData/7.0.0/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.0/SAPOData-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.0/SAPOData-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.0'

--- a/SAPOData/7.0.1/SAPOData.podspec
+++ b/SAPOData/7.0.1/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.1/SAPOData-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.1/SAPOData-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.1'

--- a/SAPOData/7.0.2/SAPOData.podspec
+++ b/SAPOData/7.0.2/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.2/SAPOData-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.2/SAPOData-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.2'

--- a/SAPOData/7.0.3/SAPOData.podspec
+++ b/SAPOData/7.0.3/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.3/SAPOData-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.3/SAPOData-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.3'

--- a/SAPOData/7.0.4/SAPOData.podspec
+++ b/SAPOData/7.0.4/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.4/SAPOData-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.4/SAPOData-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.4'

--- a/SAPOData/7.0.5/SAPOData.podspec
+++ b/SAPOData/7.0.5/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.5/SAPOData-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.5/SAPOData-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.5'

--- a/SAPOData/7.0.6/SAPOData.podspec
+++ b/SAPOData/7.0.6/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.6/SAPOData-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.6/SAPOData-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.6'

--- a/SAPOData/7.0.7/SAPOData.podspec
+++ b/SAPOData/7.0.7/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.7/SAPOData-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/7.0.7/SAPOData-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '7.0.7'

--- a/SAPOData/8.0.0/SAPOData.podspec
+++ b/SAPOData/8.0.0/SAPOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/8.0.0/SAPOData-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOData/8.0.0/SAPOData-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOData.xcframework'
     spec.framework            = 'SAPOData'
     spec.dependency  'SAPFoundation', '8.0.0'

--- a/SAPOfflineOData/3.1.2/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/3.1.2/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPOfflineOData'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.1.200/SAPOfflineOData-3.1.200-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.1.200/SAPOfflineOData-3.1.200-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPOfflineOData.framework'
   spec.framework            = 'SAPOfflineOData'
   spec.dependency           'SAPCommon', '3.1.2'

--- a/SAPOfflineOData/3.1.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/3.1.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors              = 'SAP SE'
   spec.summary              = 'SAP CP SDK for iOS - SAPOfflineOData'
   spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-  spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.1.300/SAPOfflineOData-3.1.300-Release-fat.zip' }
+  spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.1.300/SAPOfflineOData-3.1.300-Release-fat.zip' }
   spec.vendored_frameworks  = 'SAPOfflineOData.framework'
   spec.framework            = 'SAPOfflineOData'
   spec.dependency           'SAPCommon', '3.1.3'

--- a/SAPOfflineOData/3.2.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/3.2.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.2.300/SAPOfflineOData-3.2.300-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.2.300/SAPOfflineOData-3.2.300-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '3.2.3'

--- a/SAPOfflineOData/3.2.6/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/3.2.6/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.2.600/SAPOfflineOData-3.2.600-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/3.2.600/SAPOfflineOData-3.2.600-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '3.2.6'

--- a/SAPOfflineOData/4.0.10/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.10/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.10/SAPOfflineOData-4.0.10-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.10/SAPOfflineOData-4.0.10-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '4.0.10'

--- a/SAPOfflineOData/4.0.11/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.11/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.11/SAPOfflineOData-4.0.11-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.11/SAPOfflineOData-4.0.11-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '4.0.11'

--- a/SAPOfflineOData/4.0.16/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.16/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.15/SAPOfflineOData-4.0.15-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.15/SAPOfflineOData-4.0.15-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPCommon', '4.0.16'

--- a/SAPOfflineOData/4.0.18/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.18/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.18/SAPOfflineOData-4.0.18-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.18/SAPOfflineOData-4.0.18-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '4.0.18'

--- a/SAPOfflineOData/4.0.19/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.19/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-fat.zip" }
     spec.vendored_frameworks  = "#{spec.name}.framework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPOData', "#{spec.version}"

--- a/SAPOfflineOData/4.0.21/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.21/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.21/SAPOfflineOData-4.0.21-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004394/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.21/SAPOfflineOData-4.0.21-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '4.0.21'

--- a/SAPOfflineOData/4.0.4/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.4/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.4/SAPOfflineOData-4.0.4-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.4/SAPOfflineOData-4.0.4-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '4.0.4'

--- a/SAPOfflineOData/4.0.7/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.7/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.7/SAPOfflineOData-4.0.7-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.7/SAPOfflineOData-4.0.7-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '4.0.7'

--- a/SAPOfflineOData/4.0.9/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/4.0.9/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.9/SAPOfflineOData-4.0.9-Release-fat.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900003122/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/4.0.9/SAPOfflineOData-4.0.9-Release-fat.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.framework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPCommon', '4.0.7'

--- a/SAPOfflineOData/5.0.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.0.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.3/SAPOfflineOData-5.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.3/SAPOfflineOData-5.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '5.0.3'

--- a/SAPOfflineOData/5.0.5/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.0.5/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.5/SAPOfflineOData-5.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.5/SAPOfflineOData-5.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPCommon', '5.0.5'

--- a/SAPOfflineOData/5.0.6/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.0.6/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.6/SAPOfflineOData-5.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.0.6/SAPOfflineOData-5.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPCommon', '5.0.6'

--- a/SAPOfflineOData/5.1.0/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.0/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/#{spec.name}/#{spec.version}/#{spec.name}-#{spec.version}-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPOfflineOData/5.1.1/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.1/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.1/SAPOfflineOData-5.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.1/SAPOfflineOData-5.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPCommon', '5.1.1'

--- a/SAPOfflineOData/5.1.13/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.13/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.13/SAPOfflineOData-5.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.13/SAPOfflineOData-5.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '5.1.13'

--- a/SAPOfflineOData/5.1.2/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.2/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.2/SAPOfflineOData-5.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.2/SAPOfflineOData-5.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '5.1.2'

--- a/SAPOfflineOData/5.1.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => "https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.3/SAPOfflineOData-5.1.3-Release-xcframework.zip" }
+    spec.source               = { :http => "https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.3/SAPOfflineOData-5.1.3-Release-xcframework.zip" }
     spec.vendored_frameworks  = "#{spec.name}.xcframework"
     spec.framework            = "#{spec.name}"
     spec.dependency  'SAPCommon', "#{spec.version}"

--- a/SAPOfflineOData/5.1.6/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/5.1.6/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP Cloud Platform SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.6/SAPOfflineOData-5.1.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900004651/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/5.1.6/SAPOfflineOData-5.1.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPFoundation', '5.1.6'

--- a/SAPOfflineOData/6.0.2/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.0.2/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.0.2/SAPOfflineOData-6.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.0.2/SAPOfflineOData-6.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.0.2'

--- a/SAPOfflineOData/6.0.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.0.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.0.3/SAPOfflineOData-6.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.0.3/SAPOfflineOData-6.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.0.3'

--- a/SAPOfflineOData/6.1.0/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.0/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.0/SAPOfflineOData-6.1.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.0/SAPOfflineOData-6.1.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.0'

--- a/SAPOfflineOData/6.1.1/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.1/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.1/SAPOfflineOData-6.1.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.1/SAPOfflineOData-6.1.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.1'

--- a/SAPOfflineOData/6.1.10/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.10/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.10/SAPOfflineOData-6.1.10-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.10/SAPOfflineOData-6.1.10-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.10'

--- a/SAPOfflineOData/6.1.11/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.11/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.11/SAPOfflineOData-6.1.11-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.11/SAPOfflineOData-6.1.11-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.11'

--- a/SAPOfflineOData/6.1.12/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.12/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.12/SAPOfflineOData-6.1.12-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.12/SAPOfflineOData-6.1.12-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.12'

--- a/SAPOfflineOData/6.1.13/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.13/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.13/SAPOfflineOData-6.1.13-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.13/SAPOfflineOData-6.1.13-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.13'

--- a/SAPOfflineOData/6.1.14/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.14/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.14/SAPOfflineOData-6.1.14-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.14/SAPOfflineOData-6.1.14-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.14'

--- a/SAPOfflineOData/6.1.15/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.15/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.15/SAPOfflineOData-6.1.15-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.15/SAPOfflineOData-6.1.15-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.15'

--- a/SAPOfflineOData/6.1.16/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.16/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.16/SAPOfflineOData-6.1.16-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.16/SAPOfflineOData-6.1.16-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.16'

--- a/SAPOfflineOData/6.1.2/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.2/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.2/SAPOfflineOData-6.1.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.2/SAPOfflineOData-6.1.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.2'

--- a/SAPOfflineOData/6.1.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.3/SAPOfflineOData-6.1.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.3/SAPOfflineOData-6.1.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.3'

--- a/SAPOfflineOData/6.1.4/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.4/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.4/SAPOfflineOData-6.1.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.4/SAPOfflineOData-6.1.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.4'

--- a/SAPOfflineOData/6.1.5/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.5/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.5/SAPOfflineOData-6.1.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.5/SAPOfflineOData-6.1.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.5'

--- a/SAPOfflineOData/6.1.7/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.7/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.7/SAPOfflineOData-6.1.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.7/SAPOfflineOData-6.1.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.7'

--- a/SAPOfflineOData/6.1.8/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/6.1.8/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.8/SAPOfflineOData-6.1.8-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900005307/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/6.1.8/SAPOfflineOData-6.1.8-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '6.1.8'

--- a/SAPOfflineOData/7.0.0/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.0/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.0/SAPOfflineOData-7.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.0/SAPOfflineOData-7.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.0'

--- a/SAPOfflineOData/7.0.1/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.1/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.1/SAPOfflineOData-7.0.1-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.1/SAPOfflineOData-7.0.1-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.1'

--- a/SAPOfflineOData/7.0.2/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.2/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.2/SAPOfflineOData-7.0.2-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.2/SAPOfflineOData-7.0.2-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.2'

--- a/SAPOfflineOData/7.0.3/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.3/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.3/SAPOfflineOData-7.0.3-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.3/SAPOfflineOData-7.0.3-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.3'

--- a/SAPOfflineOData/7.0.4/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.4/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.4/SAPOfflineOData-7.0.4-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.4/SAPOfflineOData-7.0.4-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.4'

--- a/SAPOfflineOData/7.0.5/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.5/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.5/SAPOfflineOData-7.0.5-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.5/SAPOfflineOData-7.0.5-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.5'

--- a/SAPOfflineOData/7.0.6/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.6/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.6/SAPOfflineOData-7.0.6-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.6/SAPOfflineOData-7.0.6-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.6'

--- a/SAPOfflineOData/7.0.7/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/7.0.7/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.7/SAPOfflineOData-7.0.7-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73555000100900005862/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/7.0.7/SAPOfflineOData-7.0.7-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '7.0.7'

--- a/SAPOfflineOData/8.0.0/SAPOfflineOData.podspec
+++ b/SAPOfflineOData/8.0.0/SAPOfflineOData.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
     spec.authors              = 'SAP SE'
     spec.summary              = 'SAP BTP SDK for iOS - SAPOfflineOData Framework'
     spec.documentation_url    = 'https://help.sap.com/viewer/p/SAP_CLOUD_PLATFORM_SDK_FOR_IOS'
-    spec.source               = { :http => 'https://rbsc.repositories.sap.ondemand.com/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/8.0.0/SAPOfflineOData-8.0.0-Release-xcframework.zip' }
+    spec.source               = { :http => 'https://rbsc.repositories.cloud.sap/nexus3/repository/maven73554900100900006843/com/sap/mobile/platform/client/hcp/sdk/ios/foundation/SAPOfflineOData/8.0.0/SAPOfflineOData-8.0.0-Release-xcframework.zip' }
     spec.vendored_frameworks  = 'SAPOfflineOData.xcframework'
     spec.framework            = 'SAPOfflineOData'
     spec.dependency  'SAPOData', '8.0.0'


### PR DESCRIPTION
replaces repositories.sap.ondemand.com which will be shut down soon