### PR TITLE
ci: use Xcode 15.4 (macos-14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   verify-podspec-install:
-    runs-on: macos-13
+    runs-on: macos-14
       
     steps:
     - uses: actions/checkout@v4
@@ -102,11 +102,11 @@ jobs:
       run: sudo xcode-select -p
     - name: Determine Xcode version needed
       run: |
-        neededXcode='Xcode_15.2'    
+        neededXcode='Xcode_15.4'    
         echo "neededXcode=$neededXcode" >> $GITHUB_ENV
-    - name: "Set Xcode version 15.2"
-      if: env.neededXcode == 'Xcode_15.2'
-      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer                               
+    - name: "Set Xcode version 15.4"
+      if: env.neededXcode == 'Xcode_15.4'
+      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer                               
     - name: Create test application
       run: |
         cd .testing


### PR DESCRIPTION
Xcode 15.3 is not available but Xcode 15.4 is equivalent because it uses the same Swift compiler