### PR TITLE
ci: set explicit GITHUB_TOKEN permissions for security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ on:
 jobs:
   verify-podspec-install:
     runs-on: macos-15
-      
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v4
     - name: Create .netrc file with credentials to download binaries from SAP RSBC


### PR DESCRIPTION
Add explicit permissions block to verify-podspec-install job to comply with GitHub security requirements. The workflow needs read access to contents and write access to pull-requests for PR commenting.

This change prepares for the repository-wide switch to read-only GITHUB_TOKEN defaults, enforced on 27 May 2026.